### PR TITLE
feat: add custom gesture support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ lib/
 
 # Eslint
 .eslintcache
+
+# Docusaurus (when switching from docs branches to code branches)
+.docusaurus/

--- a/src/components/GestureHandler.tsx
+++ b/src/components/GestureHandler.tsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react';
 import { RNGestureHandler } from './RNGestureHandler';
 import { PanResponderHandler } from './PanResponderHandler';
+import type { DispatchEvents, GestureProps } from '../types';
 
 let RNGH: any = null;
 try {
@@ -11,13 +12,24 @@ try {
   );
 }
 
+type GestureHandlerProps = GestureProps & {
+  dispatchEvents: DispatchEvents;
+};
+
 export const GestureHandler = memo(function GestureHandler({
-  zrenderId,
+  dispatchEvents,
+  gesture,
   useRNGH = false,
-}: any) {
+}: GestureHandlerProps) {
   if (useRNGH && RNGH) {
-    return <RNGestureHandler RNGH={RNGH} zrenderId={zrenderId} />;
+    return (
+      <RNGestureHandler
+        RNGH={RNGH}
+        dispatchEvents={dispatchEvents}
+        gesture={gesture}
+      />
+    );
   } else {
-    return <PanResponderHandler zrenderId={zrenderId} />;
+    return <PanResponderHandler dispatchEvents={dispatchEvents} />;
   }
 });

--- a/src/components/PanResponderHandler.tsx
+++ b/src/components/PanResponderHandler.tsx
@@ -54,7 +54,7 @@ export function usePanResponder(
         onMoveShouldSetPanResponder: () => true,
         onMoveShouldSetPanResponderCapture: () => true,
         onPanResponderGrant: ({ nativeEvent }) => {
-          dispatchEvents(['mousedown', 'mousemove'], nativeEvent);
+          dispatchEvents(['mousedown'], nativeEvent);
         },
         onPanResponderMove: ({ nativeEvent }) => {
           const touches = nativeEvent.touches;

--- a/src/components/RNGestureHandler.tsx
+++ b/src/components/RNGestureHandler.tsx
@@ -2,7 +2,11 @@ import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import type { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { styles } from './styles';
-import type { DispatchEvents, RNGestureHandlerGesture } from '../types';
+import type {
+  DefaultRNGestures,
+  DispatchEvents,
+  RNGestureHandlerGesture,
+} from '../types';
 import { throttle } from '../utils/throttle';
 
 interface RNGHType {
@@ -62,7 +66,7 @@ export const getDefaultTapRNGesture = (
 export const getDefaultRNGestures = (
   Gesture: RNGHType['Gesture'],
   dispatchEvents: DispatchEvents
-) => {
+): DefaultRNGestures => {
   return [
     getDefaultPanRNGesture(Gesture, dispatchEvents),
     getDefaultPinchRNGesture(Gesture, dispatchEvents),

--- a/src/components/RNGestureHandler.tsx
+++ b/src/components/RNGestureHandler.tsx
@@ -22,7 +22,7 @@ export const getDefaultPanRNGesture = (
     .runOnJS(true)
     .maxPointers(1)
     .onBegin((e) => {
-      dispatchEvents(['mousedown', 'mousemove'], e);
+      dispatchEvents(['mousedown'], e);
     })
     .onUpdate(
       throttle((e) => {
@@ -58,7 +58,7 @@ export const getDefaultTapRNGesture = (
   return Gesture.Tap()
     .runOnJS(true)
     .onStart((e) => {
-      dispatchEvents(['mousedown', 'mousemove'], e);
+      dispatchEvents(['mousedown'], e);
     })
     .onEnd((e) => {
       dispatchEvents(['mouseup', 'click'], e);

--- a/src/components/RNGestureHandler.tsx
+++ b/src/components/RNGestureHandler.tsx
@@ -25,7 +25,7 @@ export const getDefaultPanRNGesture = (
       dispatchEvents(['mousedown', 'mousemove'], e);
     })
     .onUpdate(
-      throttle((e: any) => {
+      throttle((e) => {
         dispatchEvents(['mousemove'], e);
       }, 50)
     )
@@ -40,13 +40,15 @@ export const getDefaultPinchRNGesture = (
 ) => {
   return Gesture.Pinch()
     .runOnJS(true)
-    .onUpdate((e) => {
-      dispatchEvents(['mousewheel'], e, {
-        zrX: e.focalX,
-        zrY: e.focalY,
-        zrDelta: e.velocity / 20,
-      });
-    });
+    .onUpdate(
+      throttle((e) => {
+        dispatchEvents(['mousewheel'], e, {
+          zrX: e.focalX,
+          zrY: e.focalY,
+          zrDelta: e.velocity / 20,
+        });
+      }, 50)
+    );
 };
 
 export const getDefaultTapRNGesture = (

--- a/src/components/events.ts
+++ b/src/components/events.ts
@@ -1,35 +1,9 @@
+import type { HandlerName } from '../types';
 import { getInstance } from 'zrender/lib/zrender';
-
-declare type HandlerName =
-  | 'click'
-  | 'dblclick'
-  | 'mousewheel'
-  | 'mouseout'
-  | 'mouseup'
-  | 'mousedown'
-  | 'mousemove'
-  | 'contextmenu';
 
 const noop = () => {};
 
-export function calcDistance(x0: number, y0: number, x1: number, y1: number) {
-  const dx = x0 - x1;
-  const dy = y0 - y1;
-  return Math.sqrt(dx * dx + dy * dy);
-}
-
-function calMiddle(p0: number, p1: number) {
-  return (p0 + p1) / 2;
-}
-
-export function calcCenter(x0: number, y0: number, x1: number, y1: number) {
-  return {
-    x: calMiddle(x1, x0),
-    y: calMiddle(y1, y0),
-  };
-}
-
-export function dispatchEvent(
+export function dispatchEventsToZRender(
   zrenderId: number,
   types: HandlerName[],
   nativeEvent: any,

--- a/src/components/events.ts
+++ b/src/components/events.ts
@@ -7,7 +7,7 @@ export function dispatchEventsToZRender(
   zrenderId: number,
   types: HandlerName[],
   nativeEvent: any,
-  props: any = {
+  eventArgs: any = {
     zrX: nativeEvent.locationX || nativeEvent.x,
     zrY: nativeEvent.locationY || nativeEvent.y,
   }
@@ -19,7 +19,7 @@ export function dispatchEventsToZRender(
         preventDefault: noop,
         stopImmediatePropagation: noop,
         stopPropagation: noop,
-        ...props,
+        ...eventArgs,
       });
     });
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
 export { default as SkiaChart } from './skiaChart';
 export { default as SvgChart } from './svgChart';
 export { SVGRenderer } from './SVGRenderer';
+export * from './types';

--- a/src/skiaChart.tsx
+++ b/src/skiaChart.tsx
@@ -20,18 +20,12 @@ import {
 import { measureText } from './utils/platform';
 import { GestureHandler } from './components/GestureHandler';
 import { dispatchEventsToZRender } from './components/events';
-import type { ChartElement, CommonChartProps, DispatchEvents } from './types';
+import type { ChartElement, DispatchEvents, SkiaChartProps } from './types';
 
 export { SVGRenderer } from './SVGRenderer';
 export * from './types';
 
 setPlatformAPI({ measureText });
-
-export type SkiaChartProps = CommonChartProps & {
-  svg?: string;
-  width?: number;
-  height?: number;
-};
 
 function getSkSvg(svg?: string): SkSVG | undefined {
   // TODO: 全局替换字体做法比较暴力，或者实用定义字体，可能某些场景字体设置失效，需要修复
@@ -45,7 +39,7 @@ function getSkSvg(svg?: string): SkSVG | undefined {
 
 function SkiaComponent(
   props: SkiaChartProps,
-  ref: ForwardedRef<ChartElement | null>
+  ref: ForwardedRef<(ChartElement & any) | null>
 ) {
   const {
     svg,
@@ -59,11 +53,14 @@ function SkiaComponent(
   const [height, setHeight] = useState<number>(initialHeight ?? 0);
   const zrenderId = useRef<number>();
 
-  const dispatchEvents = useCallback<DispatchEvents>((types, nativeEvent) => {
-    if (zrenderId.current === undefined) return;
+  const dispatchEvents = useCallback<DispatchEvents>(
+    (types, nativeEvent, eventArgs) => {
+      if (zrenderId.current === undefined) return;
 
-    dispatchEventsToZRender(zrenderId.current, types, nativeEvent);
-  }, []);
+      dispatchEventsToZRender(zrenderId.current, types, nativeEvent, eventArgs);
+    },
+    []
+  );
 
   useImperativeHandle(
     ref,

--- a/src/svgChart.tsx
+++ b/src/svgChart.tsx
@@ -43,7 +43,12 @@ import { measureText } from './utils/platform';
 // import { DEFAULT_FONT_FAMILY } from './utils/font';
 import { GestureHandler } from './components/GestureHandler';
 import { dispatchEventsToZRender } from './components/events';
-import type { ChartElement, CommonChartProps, DispatchEvents } from './types';
+import type {
+  ChartElement,
+  DispatchEvents,
+  SVGChartProps,
+  SVGVNode,
+} from './types';
 
 export { SVGRenderer } from './SVGRenderer';
 export * from './types';
@@ -75,23 +80,11 @@ const tagMap = {
   mask: Mask,
 };
 
-type SVGVNodeAttrs = Record<string, string | number | undefined | boolean>;
-
 function toCamelCase(str: string) {
   var reg = /-(\w)/g;
   return str.replace(reg, function (_: any, $1: string) {
     return $1.toUpperCase();
   });
-}
-export interface SVGVNode {
-  tag: string;
-  attrs: SVGVNodeAttrs;
-  children?: SVGVNode[];
-  text?: string;
-
-  // For patching
-  elm?: Node;
-  key?: string;
 }
 
 interface SVGVEleProps {
@@ -189,13 +182,9 @@ function SvgRoot(props: SVGVEleProps) {
   );
 }
 
-type SVGChartProps = CommonChartProps & {
-  node?: SVGVNode;
-};
-
 function SvgComponent(
   props: SVGChartProps,
-  ref: ForwardedRef<ChartElement | null>
+  ref: ForwardedRef<(ChartElement & any) | null>
 ) {
   const { node, handleGesture = true, ...gestureProps } = props;
   const [svgNode, setSvgNode] = useState<SVGVNode | undefined>(node);
@@ -209,11 +198,14 @@ function SvgComponent(
   );
   const zrenderId = useRef<number>();
 
-  const dispatchEvents = useCallback<DispatchEvents>((types, nativeEvent) => {
-    if (zrenderId.current === undefined) return;
+  const dispatchEvents = useCallback<DispatchEvents>(
+    (types, nativeEvent, eventArgs) => {
+      if (zrenderId.current === undefined) return;
 
-    dispatchEventsToZRender(zrenderId.current, types, nativeEvent);
-  }, []);
+      dispatchEventsToZRender(zrenderId.current, types, nativeEvent, eventArgs);
+    },
+    []
+  );
 
   useImperativeHandle(
     ref,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ComposedGesture,
   GestureType,
   PanGesture,
   PinchGesture,
@@ -23,11 +24,14 @@ export type DispatchEvents = (
 
 export type DefaultRNGestures = [PanGesture, PinchGesture, TapGesture];
 
-export type RNGestureHandlerGestureValue = GestureType | GestureType[];
+export type RNGestureHandlerGestureValue =
+  | ComposedGesture
+  | GestureType
+  | GestureType[];
 export type RNGestureHandlerGestureFactory = (
   defaultGestures: DefaultRNGestures,
   dispatchEvents: DispatchEvents
-) => GestureType | GestureType[];
+) => ComposedGesture | GestureType | GestureType[];
 export type RNGestureHandlerGesture =
   | RNGestureHandlerGestureValue
   | RNGestureHandlerGestureFactory;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,9 @@
-import type { GestureType } from 'react-native-gesture-handler';
+import type {
+  GestureType,
+  PanGesture,
+  PinchGesture,
+  TapGesture,
+} from 'react-native-gesture-handler';
 
 export type HandlerName =
   | 'click'
@@ -13,12 +18,14 @@ export type HandlerName =
 export type DispatchEvents = (
   types: HandlerName[],
   nativeEvent: any,
-  props?: any
+  eventArgs?: any
 ) => void;
 
-type RNGestureHandlerGestureValue = GestureType | GestureType[];
-type RNGestureHandlerGestureFactory = (
-  defaultGestures: GestureType[],
+export type DefaultRNGestures = [PanGesture, PinchGesture, TapGesture];
+
+export type RNGestureHandlerGestureValue = GestureType | GestureType[];
+export type RNGestureHandlerGestureFactory = (
+  defaultGestures: DefaultRNGestures,
   dispatchEvents: DispatchEvents
 ) => GestureType | GestureType[];
 export type RNGestureHandlerGesture =
@@ -31,7 +38,7 @@ export type GestureBuiltinProps = {
 };
 
 export type GestureRNGHProps = {
-  useRNGH?: true;
+  useRNGH: true;
   gesture?: RNGestureHandlerGesture;
 };
 
@@ -42,6 +49,32 @@ type BaseChartProps = {
 };
 
 export type CommonChartProps = BaseChartProps & GestureProps;
+
+export type SkiaChartProps = CommonChartProps & {
+  svg?: string;
+  width?: number;
+  height?: number;
+};
+
+export type SVGVNodeAttrs = Record<
+  string,
+  string | number | undefined | boolean
+>;
+
+export interface SVGVNode {
+  tag: string;
+  attrs: SVGVNodeAttrs;
+  children?: SVGVNode[];
+  text?: string;
+
+  // For patching
+  elm?: Node;
+  key?: string;
+}
+
+export type SVGChartProps = CommonChartProps & {
+  node?: SVGVNode;
+};
 
 export type ChartElement = {
   dispatchEvents: DispatchEvents;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,48 @@
+import type { GestureType } from 'react-native-gesture-handler';
+
+export type HandlerName =
+  | 'click'
+  | 'dblclick'
+  | 'mousewheel'
+  | 'mouseout'
+  | 'mouseup'
+  | 'mousedown'
+  | 'mousemove'
+  | 'contextmenu';
+
+export type DispatchEvents = (
+  types: HandlerName[],
+  nativeEvent: any,
+  props?: any
+) => void;
+
+type RNGestureHandlerGestureValue = GestureType | GestureType[];
+type RNGestureHandlerGestureFactory = (
+  defaultGestures: GestureType[],
+  dispatchEvents: DispatchEvents
+) => GestureType | GestureType[];
+export type RNGestureHandlerGesture =
+  | RNGestureHandlerGestureValue
+  | RNGestureHandlerGestureFactory;
+
+export type GestureBuiltinProps = {
+  useRNGH?: false;
+  gesture?: never;
+};
+
+export type GestureRNGHProps = {
+  useRNGH?: true;
+  gesture?: RNGestureHandlerGesture;
+};
+
+export type GestureProps = GestureBuiltinProps | GestureRNGHProps;
+
+type BaseChartProps = {
+  handleGesture?: boolean;
+};
+
+export type CommonChartProps = BaseChartProps & GestureProps;
+
+export type ChartElement = {
+  dispatchEvents: DispatchEvents;
+};

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,0 +1,10 @@
+export function throttle(func: Function, wait: number) {
+  let lastExecution = 0;
+  return (...args: any) => {
+    const now = Date.now();
+    if (now - lastExecution >= wait) {
+      lastExecution = now;
+      func(...args);
+    }
+  };
+}

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,6 +1,11 @@
-export function throttle(func: Function, wait: number) {
+export type ThrottledFunction<T extends any[]> = (...args: T) => void;
+
+export function throttle<T extends any[]>(
+  func: ThrottledFunction<T>,
+  wait: number
+) {
   let lastExecution = 0;
-  return (...args: any) => {
+  return (...args: T) => {
     const now = Date.now();
     if (now - lastExecution >= wait) {
       lastExecution = now;


### PR DESCRIPTION
This PR allows users to:
- Customize gestures (`react-native-gesture-handler` only)
- Disable gesture support

Related to #64 
Documentation PR: #71 

## API
### `gesture` property (only if `useRNGH` is true)

If the user wishes to add new gestures, modify existing ones or remove them, this property allows him to do so.

`gesture` can take :
- A composed gesture
- A gesture
- A gesture array
- A function that return a composed gesture, a gesture or a gesture array

The function provides `defaultGestures` gesture array and `dispatchEvents` function to send events to ZRender.

Note: If `gesture` is an array or returns an array, gestures will be processed by race (`Gesture.Race`).

### `handleGesture` property (true by default)

If the user wishes to disable gesture support (e.g.: doesn't need it, wants to use an external gesture system), this property allows him to do so.
In addition, the reference passed to SkiaChart/SvgChart now has a `dispatchEvents` method to send events to ZRender.(`myRef.current.dispatchEvents`).

## Additional info/requests/questions

- `throttle` has its own file (exposed, so that users can use it if necessary)
- the `calc*` functions have been moved to the `PanResponderHandler` file, as they are only used here
- ref instead of state for the `zrenderId` (to avoid unnecessary re-rendering, should it be set to null when the component is unmounted?)
- Why does `PanGesture` listen to `onBegin` and not `onStart`?
- Why are `mousedown` and `mousemove` sent at the same time for a press? Is `mouseclick` not enough?
- Shouldn't we add throttle on `onUpdate` of `PinchGesture`?

