### PR TITLE
fix: Android cannot respond to gestures when the react-native version is too low

### DIFF
--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -4,5 +4,6 @@ export const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
     position: 'absolute',
+    backgroundColor:'rgba(0,0,0,0)',
   },
 });


### PR DESCRIPTION
When the react-native version is 0.62, on Android devices, absolutely positioned elements cannot respond to gestures, setting backgroundColor can solve this problem