### PR TITLE
fix: custom fontFamily in <SvgChart /> 

### DIFF
--- a/src/svgChart.tsx
+++ b/src/svgChart.tsx
@@ -115,18 +115,11 @@ function SvgEle(props: SVGVEleProps) {
       // TODO: 全局替换字体做法比较暴力，或者实用定义字体，可能某些场景字体设置失效，需要修复
       // attrs.style = attrs.style.replace(new RegExp(zrenderFontFamily, 'g'), DEFAULT_FONT_FAMILY);
 
-      const matches = attrs.style.split(';');
-      matches
-        .filter((match: string) => fontStyleReg.test(match) && match.length > 0)
-        .forEach((match: string) => {
-          const parts = match.split(':');
-          const key = parts[0]?.trim();
-          const value = parts[1]?.trim();
-          // 修复 text 属性无效的问题
-          if (key && key !== 'font-family') {
-            attrs[toCamelCase(key)] = value;
-          }
-        });
+      for (const [_, key, value] of attrs.style.matchAll(fontStyleReg)) {
+        if (key) {
+          attrs[toCamelCase(key)] = value;
+        }
+      }
     }
     if (!attrs.alignmentBaseline && attrs.dominantBaseline) {
       attrs.alignmentBaseline = 'middle';

--- a/src/svgChart.tsx
+++ b/src/svgChart.tsx
@@ -94,7 +94,7 @@ interface SVGVEleProps {
   touchEnd?: any;
 }
 
-const fontStyleReg = /([\w-]+):([\w-]+)/g;
+const fontStyleReg = /([\w-]+):([\w-]+)/;
 function SvgEle(props: SVGVEleProps) {
   const { node } = props;
   if (!node) return null;
@@ -115,11 +115,18 @@ function SvgEle(props: SVGVEleProps) {
       // TODO: 全局替换字体做法比较暴力，或者实用定义字体，可能某些场景字体设置失效，需要修复
       // attrs.style = attrs.style.replace(new RegExp(zrenderFontFamily, 'g'), DEFAULT_FONT_FAMILY);
 
-      for (const [_, key, value] of attrs.style.matchAll(fontStyleReg)) {
-        if (key) {
-          attrs[toCamelCase(key)] = value;
-        }
-      }
+      const matches = attrs.style.split(';');
+      matches
+        .filter((match: string) => fontStyleReg.test(match))
+        .forEach((match: string) => {
+          const parts = match.split(':');
+          const key = parts[0]?.trim();
+          const value = parts[1]?.trim();
+
+          if (key) {
+            attrs[toCamelCase(key)] = value;
+          }
+        });
     }
     if (!attrs.alignmentBaseline && attrs.dominantBaseline) {
       attrs.alignmentBaseline = 'middle';


### PR DESCRIPTION
While trying to use the `<SvgChart />` I noticed that i can't set custom fonts for any of the elements. I noticed that the fontFamily prop is not properly set on the react-native-svg `<Text/>` element.

The following changes fix this issue:

- Since the global flag is set on `fontStyleReg` the `test` function is stateful([documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test)). This makes the second style not match the regex. Switching to `matchAll` resolves this issue. Alternatively the global flag could be removed from the regex, but `matchAll` is better showing the intent of the code.
- the key of `font-family` is no longer ignored on purpose. Based on the code and history I could not figure out why this condition was there in the first place. 

