### PR TITLE
fix(exports): expose web chart builds via browser condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
     "./skiaChart": {
       "source": "./src/skia/skiaChart.tsx",
       "types": "./lib/typescript/src/skia/skiaChart.d.ts",
+      "browser": "./lib/module/skia/skiaChart.web.js",
       "default": "./lib/module/skia/skiaChart.js"
     },
     "./svgChart": {
       "source": "./src/svg/svgChart.tsx",
       "types": "./lib/typescript/src/svg/svgChart.d.ts",
+      "browser": "./lib/module/svg/svgChart.web.js",
       "default": "./lib/module/svg/svgChart.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
## Problem

The package ships web builds (`lib/module/skia/skiaChart.web.js`, `lib/module/svg/svgChart.web.js`), but the `exports` for `./skiaChart` and `./svgChart` only define `default`, pointing at the native build. Subpath `exports` bypass a bundler's `.web.js` platform-extension resolution, so web bundlers (webpack, Vite, esbuild) resolve the native entry, pull in `react-native-svg` / `react-native`, and fail on web. The shipped web build is unreachable.

## Fix

Add a `browser` condition to both subpaths, pointing at the existing `.web.js` builds. Additive: web bundlers pick the web build; Metro keeps resolving `default` for native. No existing resolution changes.

## Testing

Built from source (`yarn prepare`), packed, and installed into a real consumer. Web bundler (Vite via Storybook) resolves `svgChart.web.js` and renders charts on web where it previously failed; native (Metro) resolution unchanged.